### PR TITLE
refactor: numberFormatter의 유효자릿수를 설정 제거

### DIFF
--- a/Calculator/Calculator/Model/OperandFormatter.swift
+++ b/Calculator/Calculator/Model/OperandFormatter.swift
@@ -12,10 +12,8 @@ enum OperandFormatter {
         let operandNumber = NSDecimalNumber(string: operand)
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
-        numberFormatter.maximumFractionDigits = -2
-        numberFormatter.maximumIntegerDigits = 20
-        numberFormatter.maximumSignificantDigits = 20
-        numberFormatter.usesSignificantDigits = true
+        numberFormatter.maximumFractionDigits = 11
+        numberFormatter.maximumIntegerDigits = 12
         numberFormatter.roundingMode = .halfUp
         
         guard let numberFormatted = numberFormatter.string(for: operandNumber)


### PR DESCRIPTION
정수부 소수부만 설정하여 Double로 인한 소수점 오류가 보이지 않도록 수정